### PR TITLE
Organization can be preserved during syndication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Config Settings
 
     # Try username of user, whose api_key is used
     # (optional, default: None)
-    ckan.syndicate.replicate_organization = some_user_name
+    ckan.syndicate.username = some_user_name
 
 ------------------------
 Development Installation

--- a/README.rst
+++ b/README.rst
@@ -103,9 +103,9 @@ Config Settings
     # (optional, default: false)
     ckan.syndicate.replicate_organization = boolean
 
-    # Try username of user, whose api_key is used
+    # Try the username of user, whose api_key is used
     # (optional, default: None)
-    ckan.syndicate.username = some_user_name
+    ckan.syndicate.author = some_user_name
 
 ------------------------
 Development Installation

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,10 @@ Config Settings
     # (optional, default: false)
     ckan.syndicate.replicate_organization = boolean
 
+    # Try username of user, whose api_key is used
+    # (optional, default: None)
+    ckan.syndicate.replicate_organization = some_user_name
+
 ------------------------
 Development Installation
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,10 @@ Config Settings
     # (optional, default: constructed from ckanapi version and url)
     ckan.syndicate.user_agent = My User Agent
 
+    # Try to preserve dataset's organization
+    # (optional, default: false)
+    ckan.syndicate.replicate_organization = boolean
+
 ------------------------
 Development Installation
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,9 @@ Config Settings
     # (optional, default: false)
     ckan.syndicate.replicate_organization = boolean
 
-    # Try the username of user, whose api_key is used
+    # The username whose api_key is used.
+    # If the dataset already exists on the target CKAN instance, the dataset will be updated
+    # only if this option is set and its creator matches this user name
     # (optional, default: None)
     ckan.syndicate.author = some_user_name
 

--- a/ckanext/syndicate/plugin.py
+++ b/ckanext/syndicate/plugin.py
@@ -21,7 +21,7 @@ def get_syndicated_id():
 
 
 def get_syndicated_author():
-    return config.get('ckan.syndicate.username')
+    return config.get('ckan.syndicate.author')
 
 
 def get_syndicated_name_prefix():

--- a/ckanext/syndicate/plugin.py
+++ b/ckanext/syndicate/plugin.py
@@ -28,6 +28,10 @@ def get_syndicated_organization():
     return config.get('ckan.syndicate.organization', None)
 
 
+def is_organization_preserved():
+    return asbool(config.get('ckan.syndicate.replicate_organization', False))
+
+
 def syndicate_dataset(package_id, topic):
     ckan_ini_filepath = os.path.abspath(config['__file__'])
     celery.send_task(

--- a/ckanext/syndicate/plugin.py
+++ b/ckanext/syndicate/plugin.py
@@ -20,6 +20,10 @@ def get_syndicated_id():
     return config.get('ckan.syndicate.id', 'syndicated_id')
 
 
+def get_syndicated_author():
+    return config.get('ckan.syndicate.username')
+
+
 def get_syndicated_name_prefix():
     return config.get('ckan.syndicate.name_prefix', '')
 

--- a/ckanext/syndicate/tasks.py
+++ b/ckanext/syndicate/tasks.py
@@ -216,11 +216,9 @@ def _update_package(package):
 
         org = updated_package.pop('organization')
 
-        try:
-            if not is_organization_preserved():
-                raise ValueError("Ignore organization")
+        if is_organization_preserved():
             org_id = replicate_remote_organization(org)
-        except:
+        else:
             org_id = get_syndicated_organization()
 
         updated_package['owner_org'] = org_id


### PR DESCRIPTION
If config directive `ckan.syndicate.replicate_organization` then it affects on owner org of syndicated datasets. If it set to true, try to create the same organization remotely(id and image of original organization are not preserved). If error raised during creation - uses default workflow and adds dataset to default org
