### PR TITLE
Don't cause an exception if the syndicate flag is not present in extras

### DIFF
--- a/ckanext/syndicate/tasks.py
+++ b/ckanext/syndicate/tasks.py
@@ -75,7 +75,7 @@ def get_target():
 
 def filter_extras(extras):
     extras_dict = dict([(o['key'], o['value']) for o in extras])
-    del extras_dict[get_syndicate_flag()]
+    extras_dict.pop(get_syndicate_flag(), None)
     return [{'key': k, 'value': v} for (k, v) in extras_dict.iteritems()]
 
 


### PR DESCRIPTION
If the syndicate flag field is defined with ckanext-scheming it will not be present in extras and del-ing it results in an exception and syndication of datasets failing.